### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A bridge between [Django] and [Synth] that enables fast, efficient parsing and r
 
 [Django]:       https://djangoproject.com
 [Synth]:        https://github.com/ajg/synth
-[PyPI Version]: https://pypip.in/v/django-synth/badge.png
+[PyPI Version]: https://img.shields.io/pypi/v/django-synth.svg
 [Build Status]: https://travis-ci.org/ajg/django-synth.png?branch=master
 
 Installation


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-synth))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-synth`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.